### PR TITLE
Fix margins and font weight

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Example:
 ```html
 <paper-toolbar>
   <paper-icon-button icon="menu" on-tap="{{menuAction}}"></paper-icon-button>
-  <div flex>Title</div>
+  <div title>Title</div>
   <paper-icon-button icon="more" on-tap="{{moreAction}}"></paper-icon-button>
 </paper-toolbar>
 ```
@@ -41,8 +41,8 @@ When `tall`, items can pin to either the top (default), middle or bottom.  Use
 ```html
 <paper-toolbar class="tall">
   <paper-icon-button icon="menu"></paper-icon-button>
-  <div class="middle">Middle Title</div>
-  <div class="bottom">Bottom Title</div>
+  <div title class="middle">Middle Title</div>
+  <div title class="bottom">Bottom Title</div>
 </paper-toolbar>
 ```
 

--- a/bower.json
+++ b/bower.json
@@ -25,11 +25,11 @@
     "polymer": "Polymer/polymer#^0.9.0"
   },
   "devDependencies": {
-    "iron-icon": "PolymerElements/iron-icon#^0.9.0",
     "iron-icons": "PolymerElements/iron-icons#^0.9.0",
+    "paper-icon-button": "PolymerElements/paper-icon-button#^0.9.0",
     "iron-doc-viewer": "PolymerElements/iron-doc-viewer#^0.9.0",
     "test-fixture": "PolymerElements/test-fixture#^0.9.0",
-    "web-component-tester": "~2.2.6",
+    "web-component-tester": "*",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -16,70 +16,64 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
-  <link rel="import" href="../../iron-icon/iron-icon.html">
   <link rel="import" href="../../iron-icons/iron-icons.html">
+  <link rel="import" href="../../paper-icon-button/paper-icon-button.html">
   <link rel="import" href="../../paper-styles/paper-styles.html">
   <link rel="import" href="../paper-toolbar.html">
 
   <style>
-
-  paper-toolbar + paper-toolbar {
+    paper-toolbar + paper-toolbar {
       margin-top: 20px;
     }
-
-    iron-icon:not(:last-child) {
-      margin-right: 8px;
-    }
-
   </style>
 
 </head>
 <body>
 
   <paper-toolbar>
-    <iron-icon icon="menu"></iron-icon>
-    <span class="flex">Toolbar</span>
-    <iron-icon icon="refresh"></iron-icon>
-    <iron-icon icon="add">+</iron-icon>
+    <paper-icon-button icon="menu"></paper-icon-button>
+    <span title>Toolbar</span>
+    <paper-icon-button icon="refresh"></paper-icon-button>
+    <paper-icon-button icon="add">+</paper-icon-button>
   </paper-toolbar>
 
   <paper-toolbar class="tall">
-    <iron-icon icon="menu"></iron-icon>
-    <span class="flex">Toolbar: tall</span>
-    <iron-icon icon="refresh"></iron-icon>
-    <iron-icon icon="add">+</iron-icon>
+    <paper-icon-button icon="menu"></paper-icon-button>
+    <span title>Toolbar: tall</span>
+    <paper-icon-button icon="refresh"></paper-icon-button>
+    <paper-icon-button icon="add">+</paper-icon-button>
   </paper-toolbar>
 
   <paper-toolbar class="tall">
-    <iron-icon icon="menu" class="bottom"></iron-icon>
-    <span class="flex bottom">Toolbar: tall with elements pin to the bottom</span>
-    <iron-icon icon="refresh" class="bottom"></iron-icon>
-    <iron-icon icon="add" class="bottom">+</iron-icon>
+    <paper-icon-button icon="menu" class="bottom"></paper-icon-button>
+    <span title class="bottom">Toolbar: tall with elements pin to the bottom</span>
+    <paper-icon-button icon="refresh" class="bottom"></paper-icon-button>
+    <paper-icon-button icon="add" class="bottom">+</paper-icon-button>
   </paper-toolbar>
 
   <paper-toolbar class="medium-tall">
-    <iron-icon icon="menu"></iron-icon>
+    <paper-icon-button icon="menu"></paper-icon-button>
     <span class="flex"></span>
-    <iron-icon icon="refresh"></iron-icon>
-    <iron-icon icon="add">+</iron-icon>
-    <span class="bottom">Toolbar: medium-tall with label aligns to the bottom</span>
+    <paper-icon-button icon="refresh"></paper-icon-button>
+    <paper-icon-button icon="add">+</paper-icon-button>
+    <span title class="bottom">Toolbar: medium-tall with label aligns to the bottom</span>
   </paper-toolbar>
 
   <paper-toolbar class="tall">
-    <iron-icon icon="menu"></iron-icon>
+    <paper-icon-button icon="menu"></paper-icon-button>
     <div class="flex"></div>
-    <iron-icon icon="refresh"></iron-icon>
-    <iron-icon icon="add">+</iron-icon>
-    <div class="middle">label aligns to the middle</div>
-    <div class="bottom">some stuffs align to the bottom</div>
+    <paper-icon-button icon="refresh"></paper-icon-button>
+    <paper-icon-button icon="add">+</paper-icon-button>
+    <div title class="middle">label aligns to the middle</div>
+    <div title class="bottom">some stuffs align to the bottom</div>
   </paper-toolbar>
 
   <paper-toolbar class="tall">
-    <iron-icon icon="menu"></iron-icon>
+    <paper-icon-button icon="menu"></paper-icon-button>
     <div class="flex"></div>
-    <iron-icon icon="refresh"></iron-icon>
-    <iron-icon icon="add">+</iron-icon>
-    <div class="middle">element (e.g. progress) fits at the bottom of the toolbar</div>
+    <paper-icon-button icon="refresh"></paper-icon-button>
+    <paper-icon-button icon="add">+</paper-icon-button>
+    <div title class="middle">element (e.g. progress) fits at the bottom of the toolbar</div>
     <div class="bottom flex" style="height: 20px; background-color: #0f9d58;"></div>
   </paper-toolbar>
 

--- a/paper-toolbar.html
+++ b/paper-toolbar.html
@@ -7,6 +7,16 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../paper-styles/paper-styles.html">
+
+<style is="custom-style">
+  :root {
+    --paper-toolbar-background: var(--default-primary-color);
+    --paper-toolbar-color: var(--text-primary-color);
+  }
+</style>
+
 <!--
 `paper-toolbar` is a horizontal bar containing items that can be used for
 label, navigation, search and actions.  The items place inside the
@@ -18,7 +28,7 @@ Example:
 
     <paper-toolbar>
       <paper-icon-button icon="menu" on-tap="{{menuAction}}"></paper-icon-button>
-      <div flex>Title</div>
+      <div title>Title</div>
       <paper-icon-button icon="more" on-tap="{{moreAction}}"></paper-icon-button>
     </paper-toolbar>
 
@@ -41,8 +51,8 @@ When `tall`, items can pin to either the top (default), middle or bottom.  Use
 
     <paper-toolbar class="tall">
       <paper-icon-button icon="menu"></paper-icon-button>
-      <div class="middle">Middle Title</div>
-      <div class="bottom">Bottom Title</div>
+      <div title class="middle">Middle Title</div>
+      <div title class="bottom">Bottom Title</div>
     </paper-toolbar>
 
 For `medium-tall` toolbar, the middle and bottom contents overlap and are
@@ -54,22 +64,12 @@ still honored separately.
 @homepage github.io
 -->
 
-<link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../paper-styles/paper-styles.html">
-
-<style is="custom-style">
-
-  * {
-
-    --paper-toolbar-background: var(--default-primary-color);
-    --paper-toolbar-color: var(--text-primary-color);
-  }
-</style>
-
 <dom-module id="paper-toolbar">
 
   <style>
     :host {
+      @apply(--paper-toolbar);
+
       /* technical */
       display: block;
       position: relative;
@@ -81,9 +81,6 @@ still honored separately.
 
       background: var(--paper-toolbar-background);
       color: var(--paper-toolbar-color);
-      @apply(--paper-font-title);
-
-      @apply(--paper-toolbar);
     }
 
     :host(.animate) {
@@ -125,7 +122,6 @@ still honored separately.
 
       .toolbar-tools {
         height: 56px;
-        padding: 0;
       }
     }
 
@@ -162,6 +158,44 @@ still honored separately.
       pointer-events: auto;
     }
 
+    .toolbar-tools > ::content [title] {
+      @apply(--paper-font-title);
+      @apply(--layout-flex);
+
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow: hidden;
+
+      /*
+       * Polymer/polymer/issues/1525
+       * --paper-font-title defines a `font-weight`
+       * let's override its value, but we need `important!`
+       * because all mixins are resolved in rule's selector that has higher precedence
+       * than the current selector.
+       */
+      font-weight: 400 !important;
+    }
+
+    .toolbar-tools > ::content paper-icon-button[icon=menu] {
+      margin-left: -8px;
+      margin-right: 24px;
+    }
+
+    .toolbar-tools > ::content paper-icon-button + paper-icon-button {
+      margin-right: -8px;
+    }
+
+    .toolbar-tools > ::content > [title],
+    .toolbar-tools > ::content[select=".middle"] > [title],
+    .toolbar-tools > ::content[select=".bottom"] > [title] {
+      margin-left: 56px;
+    }
+
+    .toolbar-tools > ::content > paper-icon-button + [title],
+    .toolbar-tools > ::content[select=".middle"] paper-icon-button + [title],
+    .toolbar-tools > ::content[select=".bottom"] paper-icon-button + [title] {
+      margin-left: 0;
+    }
   </style>
 
   <template>


### PR DESCRIPTION
**Material design spec audit https://github.com/PolymerElements/paper-toolbar/issues/4**
- Add a `[title]` element
- Set the margins for the title according to the spec.
- Set the margins for the paper-icons / paper-icon-button
- Change `*` to `:root`
- Make the font weight lighter. I know this should be fixed in `paper-styles` as it is using `--paper-font-title`. I will also send a PR for that.
- Use `paper-icon-button` instead of `iron-icon` in the demos
- Add `text-overflow: ellipsis` to the title

cc @notwaldorf  @cdata @morethanreal   
