### PR TITLE
fix iron-component-page

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,27 +12,17 @@
 <head>
 
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>paper-toolbar</title>
 
   <script src="../webcomponentsjs/webcomponents-lite.js"></script>
-
-  <link rel="import" href="../polymer/polymer.html">
-  <link rel="import" href="../iron-doc-viewer/iron-doc-viewer.html">
-
-  <style>
-
-    body {
-      margin: 16px;
-    }
-
-  </style>
+  <link rel="import" href="../iron-component-page/iron-component-page.html">
 
 </head>
 <body>
 
-  <iron-doc-viewer src="paper-toolbar.html"></iron-doc-viewer>
+  <iron-component-page></iron-component-page>
 
 </body>
 </html>


### PR DESCRIPTION
Fixed iron-component-page to display correct documentation in index.html. Copied page from paper-scroll-header-panel.
