### PR TITLE
Fix: stop paper-toolbar content showing underneath the shadow

### DIFF
--- a/paper-toolbar.html
+++ b/paper-toolbar.html
@@ -133,7 +133,7 @@ be used as the label of the toolbar via `aria-labelledby`.
 
     #topBar {
       position: relative;
-      z-index: 1;
+      z-index: 3;
     }
 
     /* middle bar */


### PR DESCRIPTION
I was having trouble with content in the paper-toolbar displaying underneath the shadow like this

![screen shot 2015-06-10 at 10 06 12 pm](https://cloud.githubusercontent.com/assets/2122616/8080025/08a8a276-0fbd-11e5-8ea4-fe6995790f91.png)

I found that doing this in my css solved the problem.

```
paper-header-panel::shadow {
    #topBar.paper-toolbar {
        z-index: 3;
    }
}
```
