### PR TITLE
Use Strings as Object Key Names to Prevent JS Closure Renaming

### DIFF
--- a/paper-toolbar.html
+++ b/paper-toolbar.html
@@ -342,9 +342,9 @@ be used as the label of the toolbar via `aria-labelledby`.
 
       _computeBarClassName: function(barJustify) {
         var classObj = {
-          center: true,
-          horizontal: true,
-          layout: true,
+          'center': true,
+          'horizontal': true,
+          'layout': true,
           'toolbar-tools': true
         };
 


### PR DESCRIPTION
classObj's object key names are used as literals for class names.
