### PR TITLE
Add --toolbar-tools mixin,

### DIFF
--- a/paper-toolbar.html
+++ b/paper-toolbar.html
@@ -68,6 +68,7 @@ Custom property | Description | Default
 `--paper-toolbar-background` | Toolbar background color     | `--default-primary-color`
 `--paper-toolbar-color`      | Toolbar foreground color     | `--text-primary-color`
 `--paper-toolbar`            | Mixin applied to the toolbar | `{}`
+`--toolbar-tools`            | Mixin applied to the toolbar-tools | `{}`
 
 ### Accessibility
 
@@ -114,6 +115,8 @@ be used as the label of the toolbar via `aria-labelledby`.
       height: 64px;
       padding: 0 16px;
       pointer-events: none;
+
+      @apply(--toolbar-tools);
     }
 
     /*


### PR DESCRIPTION
I found no way of setting .top .middle .bottom toolbar section margins / moving them around, it appears .toolbar-tools is where placement of .top .middle .bottom is controlled. Adding mixin so it's possible to customize .top .middle .bottom location within the toolbar. For example:

``` css
  <style is="custom-style">
    :host {
      display: block;
    }
    paper-toolbar {
      --paper-toolbar-background: black;
      --paper-toolbar-color: red;
      --paper-toolbar: {
          font-size: 10px;
          height: 300px;
      };
      --toolbar-tools: {
        height: unset;
        padding: 0px 166px;
      };
    }
  </style>
```

related to http://stackoverflow.com/questions/31580579/how-to-add-content-to-the-paper-toolbar-so-it-appears-right-at-the-top

I have limited css knowledge so please feel free to reject if this is sub optimal for controlling the locations of .top .middle .bottom sections
