### PR TITLE
stop using paper-styles classes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "paper-styles": "PolymerElements/paper-styles#^1.0.0",
+    "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
     "polymer": "Polymer/polymer#^1.1.0"
   },
   "devDependencies": {

--- a/demo/index.html
+++ b/demo/index.html
@@ -19,6 +19,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../../iron-icons/iron-icons.html">
   <link rel="import" href="../../paper-icon-button/paper-icon-button.html">
   <link rel="import" href="../paper-toolbar.html">
+  <link rel="import" href="../../iron-flex-layout/iron-flex-layout.html">
 
   <style is="custom-style">
     paper-toolbar + paper-toolbar {
@@ -26,6 +27,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
     paper-toolbar.red {
       --paper-toolbar-background: red;
+    }
+    .spacer {
+      @apply(--layout-flex);
     }
   </style>
 
@@ -38,7 +42,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <paper-icon-button icon="refresh"></paper-icon-button>
     <paper-icon-button icon="add">+</paper-icon-button>
   </paper-toolbar>
-  
+
   <paper-toolbar class="red">
     <paper-icon-button icon="menu"></paper-icon-button>
     <span class="title">Toolbar: custom background color</span>
@@ -62,7 +66,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <paper-toolbar class="medium-tall">
     <paper-icon-button icon="menu"></paper-icon-button>
-    <span class="flex"></span>
+    <span class="spacer"></span>
     <paper-icon-button icon="refresh"></paper-icon-button>
     <paper-icon-button icon="add">+</paper-icon-button>
     <span class="bottom title">Toolbar: medium-tall with label aligns to the bottom</span>
@@ -70,7 +74,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <paper-toolbar class="tall">
     <paper-icon-button icon="menu"></paper-icon-button>
-    <div class="flex"></div>
+    <div class="spacer"></div>
     <paper-icon-button icon="refresh"></paper-icon-button>
     <paper-icon-button icon="add">+</paper-icon-button>
     <div class="middle title">label aligns to the middle</div>
@@ -79,7 +83,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <paper-toolbar class="tall">
     <paper-icon-button icon="menu"></paper-icon-button>
-    <div class="flex"></div>
+    <div class="spacer"></div>
     <paper-icon-button icon="refresh"></paper-icon-button>
     <paper-icon-button icon="add">+</paper-icon-button>
     <div class="middle title">element (e.g. progress) fits at the bottom of the toolbar</div>

--- a/paper-toolbar.html
+++ b/paper-toolbar.html
@@ -8,7 +8,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../paper-styles/paper-styles.html">
+<link rel="import" href="../paper-styles/default-theme.html">
+<link rel="import" href="../paper-styles/typography.html">
+<link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 
 <!--
 Material design: [Toolbars](https://www.google.com/design/spec/components/toolbars.html)
@@ -118,6 +120,8 @@ be used as the label of the toolbar via `aria-labelledby`.
         height: var(--paper-toolbar-height, 64px);
         padding: 0 16px;
         pointer-events: none;
+        @apply(--layout-horizontal);
+        @apply(--layout-center);
       }
 
       /*
@@ -226,6 +230,29 @@ be used as the label of the toolbar via `aria-labelledby`.
         left: 0;
         width: auto;
         margin: 0;
+      }
+
+      /* TODO(noms): Until we have a better solution for classes that don't use
+       * /deep/ create our own.
+       */
+      .start-justified {
+        @apply(--layout-start-justified);
+      }
+
+      .center-justified {
+        @apply(--layout-center-justified);
+      }
+
+      .end-justified {
+        @apply(--layout-end-justified);
+      }
+
+      .around-justified {
+        @apply(--layout-around-justified);
+      }
+
+      .justified {
+        @apply(--layout-justified);
       }
     </style>
 
@@ -353,24 +380,17 @@ be used as the label of the toolbar via `aria-labelledby`.
         },
 
         _computeBarClassName: function(barJustify) {
-          var classObj = {
-            'center': true,
-            'horizontal': true,
-            'layout': true,
-            'toolbar-tools': true
-          };
+          var className = 'toolbar-tools';
 
           // If a blank string or any falsy value is given, no other class name is
           // added.
           if (barJustify) {
-            var justifyClassName = (barJustify === 'justified') ?
+            className += ' ' + (barJustify === 'justified') ?
                 barJustify :
                 barJustify + '-justified';
-
-            classObj[justifyClassName] = true;
           }
 
-          return classNames(classObj);
+          return className;
         }
       });
     }());


### PR DESCRIPTION
Removes any use of the `/deep/` flex classes.

This is the most important and also most annoying element, since a) it literally substitute class names and b) it's used in `iron-component-page` and therefore in every single page of the catalog 😹:gun:

I've also explicitly called out `iron-flex-layout` in bower.json, even though it's included in `paper-styles`. I don't know, too pedantic?
