### PR TITLE
Fixes #60

### DIFF
--- a/paper-toolbar.html
+++ b/paper-toolbar.html
@@ -143,7 +143,7 @@ be used as the label of the toolbar via `aria-labelledby`.
        * TODO: Where should media query breakpoints live so they can be shared between elements?
        */
 
-      @media (max-width: 639px) {
+      @media (max-width: 600px) {
         :host {
           height: var(--paper-toolbar-sm-height, 56px);
         }


### PR DESCRIPTION
`responsiveWidth`'s default value was changed in paper-drawer-panel (https://github.com/PolymerElements/paper-drawer-panel/issues/93)  but we forgot to change the media query in paper-toolbar.
