### PR TITLE
Proposed fix for #82

### DIFF
--- a/paper-toolbar.html
+++ b/paper-toolbar.html
@@ -238,6 +238,10 @@ be used as the label of the toolbar via `aria-labelledby`.
         margin-left: 0;
       }
 
+      /**
+       * The --paper-toolbar-title mixin is applied here instead of above to
+       * fix the issue with margin-left being ignored due to css ordering.
+       */
       .toolbar-tools > ::content .title {
         @apply(--paper-toolbar-title);
       }

--- a/paper-toolbar.html
+++ b/paper-toolbar.html
@@ -208,21 +208,6 @@ be used as the label of the toolbar via `aria-labelledby`.
         pointer-events: auto;
       }
 
-      .toolbar-tools > ::content .title {
-        @apply(--paper-font-common-base);
-
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        font-size: 20px;
-        font-weight: 400;
-        line-height: 1;
-        pointer-events: none;
-
-        @apply(--layout-flex);
-        @apply(--paper-toolbar-title);
-      }
-
       /**
        * TODO: Refactor these selectors
        * Work in progress.
@@ -241,6 +226,21 @@ be used as the label of the toolbar via `aria-labelledby`.
       .toolbar-tools > ::content[select=".middle"] paper-icon-button + .title,
       .toolbar-tools > ::content[select=".bottom"] paper-icon-button + .title {
         margin-left: 0;
+      }
+
+      .toolbar-tools > ::content .title {
+        @apply(--paper-font-common-base);
+
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        font-size: 20px;
+        font-weight: 400;
+        line-height: 1;
+        pointer-events: none;
+
+        @apply(--layout-flex);
+        @apply(--paper-toolbar-title);
       }
 
       .toolbar-tools > ::content > .fit {

--- a/paper-toolbar.html
+++ b/paper-toolbar.html
@@ -208,26 +208,6 @@ be used as the label of the toolbar via `aria-labelledby`.
         pointer-events: auto;
       }
 
-      /**
-       * TODO: Refactor these selectors
-       * Work in progress.
-       */
-      .toolbar-tools > ::content paper-icon-button[icon=menu] {
-        margin-right: 24px;
-      }
-
-      .toolbar-tools > ::content > .title,
-      .toolbar-tools > ::content[select=".middle"] > .title,
-      .toolbar-tools > ::content[select=".bottom"] > .title {
-        margin-left: 56px;
-      }
-
-      .toolbar-tools > ::content > paper-icon-button + .title,
-      .toolbar-tools > ::content[select=".middle"] paper-icon-button + .title,
-      .toolbar-tools > ::content[select=".bottom"] paper-icon-button + .title {
-        margin-left: 0;
-      }
-
       .toolbar-tools > ::content .title {
         @apply(--paper-font-common-base);
 
@@ -238,9 +218,25 @@ be used as the label of the toolbar via `aria-labelledby`.
         font-weight: 400;
         line-height: 1;
         pointer-events: none;
+        margin-left: 56px;
 
         @apply(--layout-flex);
         @apply(--paper-toolbar-title);
+      }
+
+      /**
+       * TODO: Refactor these selectors
+       * Work in progress.
+       */
+      .toolbar-tools > ::content paper-icon-button[icon=menu] {
+        margin-right: 24px;
+      }
+
+
+      .toolbar-tools > ::content > paper-icon-button + .title,
+      .toolbar-tools > ::content[select=".middle"] paper-icon-button + .title,
+      .toolbar-tools > ::content[select=".bottom"] paper-icon-button + .title {
+        margin-left: 0;
       }
 
       .toolbar-tools > ::content > .fit {

--- a/paper-toolbar.html
+++ b/paper-toolbar.html
@@ -222,14 +222,6 @@ be used as the label of the toolbar via `aria-labelledby`.
         @apply(--layout-flex);
       }
 
-      /**
-       * TODO: Refactor these selectors
-       * Work in progress.
-       */
-      .toolbar-tools > ::content paper-icon-button[icon=menu] {
-        margin-right: 24px;
-      }
-
       .toolbar-tools > ::content > .title {
         margin-left: 56px;
       }
@@ -244,6 +236,10 @@ be used as the label of the toolbar via `aria-labelledby`.
        */
       .toolbar-tools > ::content .title {
         @apply(--paper-toolbar-title);
+      }
+
+      .toolbar-tools > ::content paper-icon-button[icon=menu] {
+        margin-right: 24px;
       }
 
       .toolbar-tools > ::content > .fit {

--- a/paper-toolbar.html
+++ b/paper-toolbar.html
@@ -232,7 +232,6 @@ be used as the label of the toolbar via `aria-labelledby`.
         margin-right: 24px;
       }
 
-
       .toolbar-tools > ::content > paper-icon-button + .title,
       .toolbar-tools > ::content[select=".middle"] paper-icon-button + .title,
       .toolbar-tools > ::content[select=".bottom"] paper-icon-button + .title {

--- a/paper-toolbar.html
+++ b/paper-toolbar.html
@@ -218,10 +218,8 @@ be used as the label of the toolbar via `aria-labelledby`.
         font-weight: 400;
         line-height: 1;
         pointer-events: none;
-        margin-left: 56px;
 
         @apply(--layout-flex);
-        @apply(--paper-toolbar-title);
       }
 
       /**
@@ -232,10 +230,16 @@ be used as the label of the toolbar via `aria-labelledby`.
         margin-right: 24px;
       }
 
-      .toolbar-tools > ::content > paper-icon-button + .title,
-      .toolbar-tools > ::content[select=".middle"] paper-icon-button + .title,
-      .toolbar-tools > ::content[select=".bottom"] paper-icon-button + .title {
+      .toolbar-tools > ::content > .title {
+        margin-left: 56px;
+      }
+
+      .toolbar-tools > ::content > paper-icon-button + .title {
         margin-left: 0;
+      }
+
+      .toolbar-tools > ::content .title {
+        @apply(--paper-toolbar-title);
       }
 
       .toolbar-tools > ::content > .fit {


### PR DESCRIPTION
Reorder css rules to prevent `margin-left` from being ignored by `--paper-toolbar-title` mixin.

Fixes #82.
