### PR TITLE
Don't remove margin-left when icon button is hidden

### DIFF
--- a/paper-toolbar.html
+++ b/paper-toolbar.html
@@ -226,7 +226,7 @@ be used as the label of the toolbar via `aria-labelledby`.
         margin-left: 56px;
       }
 
-      .toolbar-tools > ::content > paper-icon-button + .title {
+      .toolbar-tools > ::content > paper-icon-button:not([hidden]) + .title {
         margin-left: 0;
       }
 


### PR DESCRIPTION
Quick (untested) suggestion.

Sometimes it may be relevant to hide the back or menu icon button on some pages when a paper-toolbar is shared between pages. In that case the button isn't actually there, so the margin-left removal shouldn't be applied.
