### PR TITLE
IE 10 topBar layout fix 

### DIFF
--- a/paper-toolbar.html
+++ b/paper-toolbar.html
@@ -173,6 +173,7 @@ be used as the label of the toolbar via `aria-labelledby`.
 
       #topBar {
         position: relative;
+        z-index: 1;
       }
 
       /* middle bar */
@@ -218,7 +219,7 @@ be used as the label of the toolbar via `aria-labelledby`.
         font-weight: 400;
         line-height: 1;
         pointer-events: none;
-
+        @apply(--layout);
         @apply(--layout-flex);
       }
 


### PR DESCRIPTION
In IE 10, the `paper-toolbar` layout buttons next to title are not aligned property and the buttons in the topBar are not responding on click.

This happens even in the [demo page](https://elements.polymer-project.org/bower_components/paper-toolbar/demo/index.html) of `paper-toolbar` in IE 10.

These issues has been fixed with this commit. Kindly check it out.

![image](https://cloud.githubusercontent.com/assets/5305600/17164661/0252bc52-53e8-11e6-9082-d317d5700c6b.png)

Fixes #30 
