### PR TITLE
Add slots for all light dom children in examples

### DIFF
--- a/paper-toolbar.html
+++ b/paper-toolbar.html
@@ -28,9 +28,9 @@ Example:
 
 ```html
 <paper-toolbar>
-  <paper-icon-button icon="menu" on-tap="menuAction"></paper-icon-button>
-  <div class="title">Title</div>
-  <paper-icon-button icon="more-vert" on-tap="moreAction"></paper-icon-button>
+  <paper-icon-button slot="top" icon="menu" on-tap="menuAction"></paper-icon-button>
+  <div slot="top" class="title">Title</div>
+  <paper-icon-button slot="top" icon="more-vert" on-tap="moreAction"></paper-icon-button>
 </paper-toolbar>
 ```
 
@@ -39,7 +39,7 @@ class on the `paper-toolbar`. This will make the toolbar 3x the normal height.
 
 ```html
 <paper-toolbar class="tall">
-  <paper-icon-button icon="menu"></paper-icon-button>
+  <paper-icon-button slot="top" icon="menu"></paper-icon-button>
 </paper-toolbar>
 ```
 
@@ -48,7 +48,7 @@ toolbar 2x the normal height.
 
 ```html
 <paper-toolbar class="medium-tall">
-  <paper-icon-button icon="menu"></paper-icon-button>
+  <paper-icon-button slot="top" icon="menu"></paper-icon-button>
 </paper-toolbar>
 ```
 
@@ -57,7 +57,7 @@ When `tall`, items can pin to either the top (default), middle or bottom. Use
 
 ```html
 <paper-toolbar class="tall">
-  <paper-icon-button icon="menu"></paper-icon-button>
+  <paper-icon-button slot="top" icon="menu"></paper-icon-button>
   <div slot="middle" class="title">Middle Title</div>
   <div slot="bottom" class="title">Bottom Title</div>
 </paper-toolbar>


### PR DESCRIPTION
If I read the element and the recommendation for upgrading to 2.0 correctly, all light dom children must have a slot to be distributed.